### PR TITLE
Main: Fixes the javascript issue so the extension can now execute production.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 
 
 
-	<body class ="background" background="images/background1.jpg" onload="startTime()">
-		<section>			
+	<body class ="background" background="images/background1.jpg">
+		<section>
 
 			<div class="greeting main-class">
 				<h1>Welcome to ProductiVision!</h1>
@@ -30,15 +30,15 @@
 
 
 			<div class="calendar">
-				
+
 			</div>
 
 			<div class="to-do">
-				
+
 			</div>
 
 			<div class="bg">
-		  		
+
 			</div>
 		</section>
 

--- a/js/production.js
+++ b/js/production.js
@@ -26,7 +26,7 @@ function twelveClock(i) {
 //     var txt1 = document.getElementById("txt1");
 //     var txt2 = document.getElementById("txt2");
 //     txt.ondblclick = txtDblClick();
-//     function txtDblClick () { 
+//     function txtDblClick () {
 //     }
 // }
 
@@ -130,3 +130,6 @@ function setMonth(i) {
 		return i;
 	}
 }
+
+// Call startTime() when elements with the background class load (the body tag)
+document.querySelector(".background").addEventListener("onload", startTime());

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,14 @@
 "description": "This is a new tab page for productivity",
 "version": "1.0.0",
 "manifest_version": 2,
-"icons": {
-"128": "youricon.png"
-},
-"chrome_url_overrides" : { "yourHTML.html": ""
-}
+"chrome_url_overrides" : {
+    "newtab": "index.html"
+  },
+"content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "css": ["css/bootstrap.css", "css/style"],
+      "js": ["js/production.js"]
+    }],
+"web_accessible_resources": ["js/production.js"]
 }


### PR DESCRIPTION
Important:

When dealing with chrome extensions, we have to add listeners to the javascript files themselves as they share the DOM of the page that they are associated with. So, instead of calling startTime() inline in index.html, I moved it to production.js as an event listener to elements that have the .background class, which in this case would be the body tag. I would refer to the last comment in the following StackOverflow question in order to get a better idea of what I'm talking about - http://stackoverflow.com/questions/17933234/chrome-extension-how-to-a-call-a-function-defined-in-content-script.

Other Changes:

Temporarily removed the icon from the manifest file since it wasn't allowing me to load the extension
